### PR TITLE
#90 Adds global text search field that includes TEI Header nodes

### DIFF
--- a/search-fields.xml
+++ b/search-fields.xml
@@ -24,6 +24,10 @@
 	This field defines an "id" field which must identify the text uniquely and persistently. It is used by Solr as a unique identifier.
 	-->
 	<field name="id" xpath="/TEI/@xml:id"/>
+	<!--
+	This field defines an "teiHeader" field which extracts selected text noded from the TEI header
+	-->
+	<field name="tei-header" xpath="/TEI/teiHeader//text()"/>
 	<!-- 
 	This field defines a "title" field containing a composite value aggregated from various components of the msIdentifier.
 	-->

--- a/xslt/update-schema-from-field-definitions.xsl
+++ b/xslt/update-schema-from-field-definitions.xsl
@@ -70,10 +70,18 @@
 				<xsl:call-template name="define-field">
 					<xsl:with-param name="name" select=" 'diplomatic' "/>
 				</xsl:call-template>				
+				<xsl:call-template name="define-field">
+					<xsl:with-param name="name" select=" 'tei-header' "/>
+				</xsl:call-template>
 				<!-- define a "text" field that's a copy of "introduction", "normalized", and "diplomatic" -->
 				<xsl:call-template name="define-field">
 					<xsl:with-param name="name" select=" 'text' "/>
 				</xsl:call-template>
+				<!-- define "all" field that's a copy of everything in text and select teiHeader text nodes -->
+				<xsl:call-template name="define-field">
+					<xsl:with-param name="name" select=" 'all' "/>
+				</xsl:call-template>
+
 				<xsl:call-template name="add-copy-field">
 					<xsl:with-param name="source" select=" 'introduction' "/>
 					<xsl:with-param name="destination" select=" 'text' "/>
@@ -86,7 +94,23 @@
 					<xsl:with-param name="source" select=" 'diplomatic' "/>
 					<xsl:with-param name="destination" select=" 'text' "/>
 				</xsl:call-template>
-				
+				<xsl:call-template name="add-copy-field">
+					<xsl:with-param name="source" select=" 'introduction' "/>
+					<xsl:with-param name="destination" select=" 'all' "/>
+				</xsl:call-template>
+				<xsl:call-template name="add-copy-field">
+					<xsl:with-param name="source" select=" 'normalized' "/>
+					<xsl:with-param name="destination" select=" 'all' "/>
+				</xsl:call-template>
+				<xsl:call-template name="add-copy-field">
+					<xsl:with-param name="source" select=" 'diplomatic' "/>
+					<xsl:with-param name="destination" select=" 'all' "/>
+				</xsl:call-template>
+				<xsl:call-template name="add-copy-field">
+					<xsl:with-param name="source" select=" 'tei-header' "/>
+					<xsl:with-param name="destination" select=" 'all' "/>
+				</xsl:call-template>
+
 				<!-- define Solr fields corresponding to the facets and search fields defined in the "search-fields.xml" file -->
 				<xsl:for-each select="/*/fields/field">
 					<xsl:call-template name="define-field">


### PR DESCRIPTION
Adding a new field for text searching that includes text nodes from the TEI header.  An additional field allows for creating separate behaviors between the advanced search text field and the global site search.