### PR TITLE
Changing Xubmit locations after server migrations

### DIFF
--- a/xproc/administration.xpl
+++ b/xproc/administration.xpl
@@ -75,7 +75,7 @@
 	<p:declare-step name="download-bibliography" type="chymistry:download-bibliography">
 		<p:input port="source"/>
 		<p:output port="result"/>
-		<p:load href="http://algernon.dlib.indiana.edu:8080/xubmit/rest/repository/newtonbib/CHYM000001.xml"/>
+		<p:load href="https://textproc.dlib.indiana.edu/xubmit/rest/repository/newtonbib/CHYM000001.xml"/>
 		<p:store href="../p5/CHYM000001.xml"/>
 		<p:identity>
 			<p:input port="source">
@@ -98,7 +98,7 @@
 		<!-- algernon.dlib.indiana.edu:8080 -->
 		<!-- host was textproc.dlib.indiana.edu -->
 		<p:option name="dc-coverage-regex"/>
-		<p:variable name="xubmit-base-uri" select=" 'http://textproc.dlib.indiana.edu/xubmit/rest/repository/newtonchym/' "/>
+		<p:variable name="xubmit-base-uri" select=" 'https://textproc.dlib.indiana.edu/xubmit/rest/repository/newtonchym/' "/>
 		<p:xslt name="manifest">
 			<p:with-param name="base-uri" select="$xubmit-base-uri"/>
 			<p:with-param name="dc-coverage-regex" select="$dc-coverage-regex"/>

--- a/xproc/convert-to-p5.xpl
+++ b/xproc/convert-to-p5.xpl
@@ -12,7 +12,7 @@
 		<p:input port="source"/>
 		<p:output port="result"/>
 		<p:option name="dc-coverage-regex"/>
-		<p:variable name="xubmit-base-uri" select=" 'http://algernon.dlib.indiana.edu:8080/xubmit/rest/repository/newton/' "/>
+		<p:variable name="xubmit-base-uri" select=" 'https://textproc.dlib.indiana.edu/xubmit/rest/repository/newton/' "/>
 		<p:xslt name="manifest">
 			<p:with-param name="base-uri" select="$xubmit-base-uri"/>
 			<p:with-param name="dc-coverage-regex" select="$dc-coverage-regex"/>

--- a/xslt/html-directory-listing.xsl
+++ b/xslt/html-directory-listing.xsl
@@ -4,7 +4,7 @@
 	xmlns:c="http://www.w3.org/ns/xproc-step" 
 	xmlns="http://www.w3.org/1999/xhtml">
 	
-	<xsl:variable name="xubmit-base-url" select=" 'http://algernon.dlib.indiana.edu:8080/xubmit/rest/repository/newton/' "/>
+	<xsl:variable name="xubmit-base-url" select=" 'https://textproc.dlib.indiana.edu/xubmit/rest/repository/newton/' "/>
 
 	<xsl:template match="/c:directory">
 		<html>


### PR DESCRIPTION
The Xubmit service was migrated to new servers and should only be addressed via it's top-level secure domain name, textproc.dlib.indiana.edu.  This fixes all of the Xproc bits that hard coded old hostnames and ports.

Fixes #116 