### PR TITLE
Fixing catchwords

### DIFF
--- a/static/css/tei.css
+++ b/static/css/tei.css
@@ -342,12 +342,18 @@ NEW >> April 2012
 
 .type-catch {
 	text-align: left;
-	margin-left: 25em
+	text-indent: 25em;
 }
 
 .type-pag {
 	width: 65%
 }
+/* rightmid placed here because only used with catchwords in double columns */
+.place-rightmid{
+    text-align: left;
+    margin-left: -10em;
+    display: block;
+    }
 
 .rend-parallel-docs {
 	display: flex;


### PR DESCRIPTION
Updated in order to make all catchwords (both those in single columns and those in double columns work correctly). The basic change was to edit the .type-catch template by changing margin-left to text-indent, keeping the 25em value. Then, I added a template for .place-rightmid (place="rightmid" was the intended attribute in the encoding guide, but no such template existed in the CSS).  That template aligns left, makes it a block element, and sets the margin as -10em. I've tested this against the manuscript that primarily needs this (ALCH00004) and "normal" (single column) manuscripts, and it seems to work.